### PR TITLE
Fixed refLocs input to fixupMapping()

### DIFF
--- a/get_chanlocs.m
+++ b/get_chanlocs.m
@@ -198,7 +198,7 @@ end
 %% autoMapElectrodes
 if ~opts.createMontageTemplate
     [elec.elecpos, affineTransformedRefLocs] = autoMapElectrodes(montageTemplate.refLocs, elec.elecpos);
-    elec.elecpos = fixupMapping(refLocs, elec.elecpos, affineTransformedRefLocs, head_surface);
+    elec.elecpos = fixupMapping(montageTemplate.refLocs, elec.elecpos, affineTransformedRefLocs, head_surface);
 end
 
 %% save montageTemplate.mat


### PR DESCRIPTION
Error in get_chanlocs (line 201): unrecognized function or variable 'refLocs'.  Fixed so that fixupMapping() uses "montageTemplate.refLocs" as first input instead of "refLocs"